### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,15 +13,15 @@ Description
     :target: https://coveralls.io/r/kmichel/po-localization
     :alt: Coverage
 
-.. image:: https://pypip.in/version/po_localization/badge.svg
+.. image:: https://img.shields.io/pypi/v/po_localization.svg
     :target: https://pypi.python.org/pypi/po_localization/
     :alt: Latest Release
 
-.. image:: https://pypip.in/py_versions/po_localization/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/po_localization.svg
     :target: https://pypi.python.org/pypi/po_localization/
     :alt: Supported Python Versions
 
-.. image:: https://pypip.in/license/po_localization/badge.svg
+.. image:: https://img.shields.io/pypi/l/po_localization.svg
     :target: https://pypi.python.org/pypi/po_localization/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20po-localization))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `po-localization`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.